### PR TITLE
[Fix] 删去过时的libmpv API

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,15 @@
+lingmo-videoplayer (1.9.9-1) unstable; urgency=high
+
+  * Remove abandoned api useage for libmpv.
+
+ -- Elysia <c.elysia@foxmail.com>  Sat, 09 Mar 2024 20:16:32 +0800
+
+
 lingmo-videoplayer (1.9.9) unstable; urgency=high
 
   * Fix some issues
 
  -- LingmoOS Team <2422586862@qq.com>  Tue, 05 Oct 2021 20:16:32 +0800
-
-
 
 lingmo-videoplayer (0.5-3) unstable; urgency=high
 

--- a/src/mpvobject.cpp
+++ b/src/mpvobject.cpp
@@ -74,7 +74,7 @@ QOpenGLFramebufferObject * MpvRenderer::createFramebufferObject(const QSize &siz
     // init mpv_gl:
     if (!obj->mpv_gl)
     {
-        mpv_opengl_init_params gl_init_params{get_proc_address_mpv, nullptr, nullptr};
+        mpv_opengl_init_params gl_init_params{get_proc_address_mpv, nullptr};
         mpv_render_param params[]{
             {MPV_RENDER_PARAM_API_TYPE, const_cast<char *>(MPV_RENDER_API_TYPE_OPENGL)},
             {MPV_RENDER_PARAM_OPENGL_INIT_PARAMS, &gl_init_params},


### PR DESCRIPTION
This allows build in Debain 13 and Ubuntu 24.04